### PR TITLE
Fix common non-major bugs

### DIFF
--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -280,6 +280,15 @@ fun String.convertDependencies(): String {
     }
 }
 
+// fileTree(dir: "libs", include: ["*.jar"])
+// becomes
+// fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar")))
+fun String.convertFileTree(): String {
+    val fileTreeString = """fileTree\(dir(\s*):(\s*)"libs"(\s*),(\s*)include(\s*):(\s*)\["\*.jar"\]\)""".toRegex()
+
+    return this.replace(fileTreeString, """fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar")))""")
+}
+
 
 // signingConfig signingConfigs.release
 // becomes
@@ -559,6 +568,8 @@ fun String.convertInclude(): String {
     val includeExp = "include$expressionBase".toRegex()
 
     return this.replace(includeExp) { includeBlock ->
+        if(includeBlock.value.contains("include\"")) return@replace includeBlock.value // exclude: "include" to
+
         // avoid cases where some lines at the start/end are blank
         val multiLine = includeBlock.value.split('\n').count { it.isNotBlank() } > 1
 
@@ -704,6 +715,7 @@ val convertedText = textToConvert
         .replaceApostrophes()
         .replaceDefWithVal()
         .convertMapExpression() // Run before array
+        .convertFileTree()
         .convertArrayExpression()
         .convertManifestPlaceHoldersWithMap() // Run after convertMapExpression
         .convertVariableDeclaration()

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -204,6 +204,18 @@ fun String.convertPlugins(): String {
     }
 }
 
+// apply from: "kotlin-android"
+// becomes
+// apply(from = "kotlin-android")
+fun String.convertPluginsFrom(): String {
+    val pluginsExp = """apply from: (\S+)""".toRegex()
+
+    return this.replace(pluginsExp) {
+        val (pluginId) = it.destructured
+        "apply(from = $pluginId)"
+    }
+}
+
 fun String.convertAndroidBuildConfigFunctions(): String {
     val outerExp = """(buildConfigField|resValue|flavorDimensions|exclude|java.srcDir)\s+(".*")""".toRegex()
     // packagingOptions > exclude
@@ -674,6 +686,7 @@ val convertedText = textToConvert
         .convertVariableDeclaration()
         .convertPlugins()
         .convertPluginsIntoOneBlock()
+        .convertPluginsFrom()
         .convertVariantFilter()
         .convertAndroidBuildConfigFunctions()
         .convertCompileToImplementation()

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -533,6 +533,7 @@ fun String.convertInternalBlocks(): String {
             .addIsToStr("buildTypes", "debuggable")
             .addIsToStr("buildTypes", "minifyEnabled")
             .addIsToStr("buildTypes", "shrinkResources")
+            .addIsToStr("", "transitive")
 }
 
 fun String.addIsToStr(blockTitle: String, transform: String): String {

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -594,6 +594,29 @@ fun String.convertExcludeClasspath(): String {
     }
 }
 
+// exclude module: 'module-id'
+// becomes
+// exclude(module = "module-id")
+fun String.convertExcludeModules(): String {
+    val fullLineExp = """exclude module: (\S+)""".toRegex()
+
+    return this.replace(fullLineExp) {
+        val (moduleId) = it.destructured
+        "exclude(module = $moduleId)"
+    }
+}
+
+// exclude group: 'group-id'
+// becomes
+// exclude(group = "group-id")
+fun String.convertExcludeGroups(): String {
+    val fullLineExp = """exclude group: (\S+)""".toRegex()
+
+    return this.replace(fullLineExp) {
+        val (groupId) = it.destructured
+        "exclude(group = $groupId)"
+    }
+}
 
 // classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 // becomes
@@ -704,6 +727,8 @@ val convertedText = textToConvert
         .convertSourceSets()
         .convertSigningConfigs()
         .convertExcludeClasspath()
+        .convertExcludeModules()
+        .convertExcludeGroups()
         .convertJetBrainsKotlin()
         .convertSigningConfigBuildType()
         .convertExtToExtra()

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -258,6 +258,8 @@ fun String.convertDependencies(): String {
     val validKeywords = "(?!$gradleKeywords\\s*(\\{|\"\\)|\\.))$gradleKeywords.*".toRegex()
 
     return this.replace(validKeywords) { substring ->
+        // By pass sth like: implementation(":epoxy-annotations") { ... }
+        if (substring.value.contains("""\)(\s*)\{""".toRegex())) return@replace substring.value
 
         // retrieve the comment [//this is a comment], if any
         val comment = "\\s*\\/\\/.*".toRegex().find(substring.value)?.value ?: ""

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -239,7 +239,7 @@ fun String.convertCompileToImplementation(): String {
 fun String.convertDependencies(): String {
 
     val testKeywords = "testImplementation|androidTestImplementation|debugImplementation|compileOnly|testCompileOnly|runtimeOnly|developmentOnly"
-    val gradleKeywords = "($testKeywords|implementation|api|annotationProcessor|classpath|kapt|kaptTest|kaptAndroidTest|check)".toRegex()
+    val gradleKeywords = "($testKeywords|implementation|api|annotationProcessor|classpath|kaptTest|kaptAndroidTest|kapt|check)".toRegex()
 
     // ignore cases like kapt { correctErrorTypes = true } and apply plugin: ('kotlin-kapt") but pass kapt("...")
     // ignore keyWord followed by a space and a { or a " and a )


### PR DESCRIPTION
Overview
-
On using this script to migrate around 50 Groovy Gradle files to Kotlin, it was really helpful. However some conversion bugs were discovered. It was easier fixing the bugs in the script logic rather than manually repeating them among all the converted files. The issues fixed are listed below

Type of change:
-
Bug fixes

What's the purpose of this PR?
-
Fix bugs found in conversion logic

<sub>N.B Commit by commit review can be helpful</sub>

What is the impact of this change?
-
More reliable output by the script

List of Groovy input giving wrong output before this proposed change:
-
* `kaptAndroidTest "com.some.dependency:1.0.0"`
* `kaptTest "com.some.dependency:1.0.0"`
* `apply from: "myfile.gradle"`
* `fileTree(dir: "libs", include: ["*.jar"])`
*
```groovy
implementation('com.some.dependency:1.0.0') {
    ...
}
``` 
*
```groovy
implementation('com.some.dependency:1.0.0') {
    exclude module: 'my-module'
}
``` 
*
```groovy
implementation('com.some.dependency:1.0.0') {
    exclude group: 'my-group'
}
```
*
```groovy
implementation('com.some.dependency:1.0.0') {
    transitive = true
}
```