### PR TITLE
Update script to support namespace property

### DIFF
--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -443,7 +443,7 @@ fun String.addEquals(): String {
     val signing = "keyAlias|keyPassword|storeFile|storePassword"
     val other = "multiDexEnabled|correctErrorTypes|javaMaxHeapSize|jumboMode|dimension|useSupportLibrary"
     val databinding = "dataBinding|viewBinding"
-    val defaultConfig = "applicationId|minSdk|targetSdk|versionCode|versionName|testInstrumentationRunner"
+    val defaultConfig = "applicationId|minSdk|targetSdk|versionCode|versionName|testInstrumentationRunner|namespace"
     val negativeLookAhead = "(?!\\{)[^\\s]" // Don't want '{' as next word character
 
     val versionExp = """($compileSdk|$defaultConfig|$signing|$other|$databinding)\s*${negativeLookAhead}.*""".toRegex()


### PR DESCRIPTION
[AGP 7.3.0](https://developer.android.com/studio/releases/gradle-plugin#package-deprecated) adds a namespace property to the default config that replaces declaring namespaces in the `AndroidManifest.xml`, this PR just adds support to properly convert the `namespace` property from Groovy to Kotlin. 