### PR TITLE
Update script to support buildFeature block

### DIFF
--- a/expected_build_gradle.kts
+++ b/expected_build_gradle.kts
@@ -41,6 +41,7 @@ dependencies {
   coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0")
   ksp("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
+  implementation("androidx.compose.ui:ui:1.3.2")
 }
 
 testImplementation(group = "junit", name = "junit", version = "4.12")
@@ -153,6 +154,17 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.3.2"
+    }
+    buildFeatures {
+        aidl = false
+        compose = true
+        buildConfig = true
+        prefab = true
+        renderScript = true
+        resValues = true
+        shaders = true
+        dataBinding = false
+        viewBinding = true
     }
 }
 compileOptions {

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -721,6 +721,20 @@ fun String.replaceCoreLibraryDesugaringEnabled(): String = this.replace(
     oldValue = "coreLibraryDesugaringEnabled", newValue = "isCoreLibraryDesugaringEnabled"
 )
 
+// compose true
+// dataBinding false
+// becomes
+// compose = true
+// dataBinding = false
+fun String.convertBuildFeatures(): String {
+    val buildFeatures = "(dataBinding|viewBinding|aidl|buildConfig|prefab|renderScript|resValues|shaders|compose)"
+    val state = "(false|true)"
+
+    return this.replace("$buildFeatures\\s$state".toRegex()) { result ->
+    result.value.replace(" ", " = ")
+    }
+}
+
 print("[${currentTimeFormatted()}] -- Starting conversion.. ")
 
 val convertedText = textToConvert
@@ -759,6 +773,7 @@ val convertedText = textToConvert
         .convertExtToExtra()
         .addParenthesisToId()
         .replaceColonWithEquals()
+        .convertBuildFeatures()
 
 
 println("Success!")

--- a/test_build_gradle
+++ b/test_build_gradle
@@ -37,6 +37,7 @@ dependencies {
   coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
   detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0'
   ksp 'com.squareup.moshi:moshi-kotlin-codegen:1.14.0'
+  implementation "androidx.compose.ui:ui:1.3.2"
 }
 
 testImplementation(group: "junit", name: "junit", version: "4.12")
@@ -144,6 +145,17 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion "1.3.2"
+    }
+    buildFeatures {
+        aidl false
+        compose true
+        buildConfig true
+        prefab true
+        renderScript true
+        resValues true
+        shaders true
+        dataBinding false
+        viewBinding true
     }
 }
 compileOptions {


### PR DESCRIPTION
This adds support for converting the `buildFeatures` block! 

I'm bad at regex so instead of updating `addEquals` to better filter out false positives I created a new `convertBuildFeatures` function at the end that will look for all the buildFeatures _and_ what they're set to and then update them to include the equals.  

Let me know if this is okay or if you'd preview something a little smarter 😅


