### PR TITLE
Fix broken CI 

### DIFF
--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -444,7 +444,7 @@ fun String.addEquals(): String {
     val other = "multiDexEnabled|correctErrorTypes|javaMaxHeapSize|jumboMode|dimension|useSupportLibrary|kotlinCompilerExtensionVersion"
     val databinding = "dataBinding|viewBinding"
     val defaultConfig = "applicationId|minSdk|targetSdk|versionCode|versionName|testInstrumentationRunner|namespace"
-    val negativeLookAhead = "(?!\\{)[^\\s]" // Don't want '{' as next word character
+    val negativeLookAhead = "(?!\\{)[^Version\\s]" // Don't want '{' as next word character
 
     val versionExp = """($compileSdk|$defaultConfig|$signing|$other|$databinding)\s*${negativeLookAhead}.*""".toRegex()
 


### PR DESCRIPTION
#42 seems to have broken main since we want to add the equals for `minSdk`, `compileSdk` and `targetSdk` but not `compileSdkVersion`, `minSdkVersion` or `targetSdkVersion`