### PR TITLE
Update script to support coreLibraryDesugaring, detektPlugins and ksp dependency declarations

### DIFF
--- a/expected_build_gradle.kts
+++ b/expected_build_gradle.kts
@@ -38,6 +38,9 @@ dependencies {
   compileOnly(group = "commons-io", name = "commons-io", version = "2.6")
   testCompileOnly(group = "org.apache.commons", name = "commons-math3", version = "3.6.1")
   customFlavorImplementation "a.lib.com"
+  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
+  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0")
+  ksp("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
 }
 
 testImplementation(group = "junit", name = "junit", version = "4.12")

--- a/gradlekotlinconverter.kts
+++ b/gradlekotlinconverter.kts
@@ -252,7 +252,7 @@ fun String.convertCompileToImplementation(): String {
 fun String.convertDependencies(): String {
 
     val testKeywords = "testImplementation|androidTestImplementation|debugImplementation|compileOnly|testCompileOnly|runtimeOnly|developmentOnly"
-    val gradleKeywords = "($testKeywords|implementation|api|annotationProcessor|classpath|kaptTest|kaptAndroidTest|kapt|check)".toRegex()
+    val gradleKeywords = "($testKeywords|implementation|api|annotationProcessor|classpath|kaptTest|kaptAndroidTest|kapt|check|ksp|coreLibraryDesugaring|detektPlugins)".toRegex()
 
     // ignore cases like kapt { correctErrorTypes = true } and apply plugin: ('kotlin-kapt") but pass kapt("...")
     // ignore keyWord followed by a space and a { or a " and a )

--- a/test_build_gradle
+++ b/test_build_gradle
@@ -34,6 +34,9 @@ dependencies {
   compileOnly group: 'commons-io', name: 'commons-io', version: '2.6'
   testCompileOnly group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   customFlavorImplementation 'a.lib.com'
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+  detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0'
+  ksp 'com.squareup.moshi:moshi-kotlin-codegen:1.14.0'
 }
 
 testImplementation(group: "junit", name: "junit", version: "4.12")


### PR DESCRIPTION
_Partial_ follow up to #45 to support converting the `coreLibraryDesugaring` dependency declaration. 

I also added `ksp` and `detektPlugins` for projects that make use of the KSP and Detekt plugins. 