### PR TITLE
fix(logic): correctly convert various data types for named arguments

### DIFF
--- a/web/app/logic.test.ts
+++ b/web/app/logic.test.ts
@@ -1,0 +1,61 @@
+
+import { GradleToKtsConverter } from './logic';
+
+const converter = new GradleToKtsConverter();
+// @ts-ignore - Accessing private method for testing purposes
+const replaceColonWithEquals = (text: string) => converter.replaceColonWithEquals(text);
+
+const testCases = [
+  {
+    name: 'should convert named arguments with string values',
+    input: 'someFunction(name: "test")',
+    expected: 'someFunction(name = "test")',
+  },
+  {
+    name: 'should convert named arguments with numeric values',
+    input: 'myFunction(value: 123)',
+    expected: 'myFunction(value = 123)',
+  },
+  {
+    name: 'should convert named arguments with boolean values',
+    input: 'yetAnother(flag: false)',
+    expected: 'yetAnother(flag = false)',
+  },
+  {
+    name: 'should handle multiple named arguments with mixed types',
+    input: 'complex(name: "value", number: 99, bool: true, other: "string")',
+    expected: 'complex(name = "value", number = 99, bool = true, other = "string")',
+  },
+  {
+    name: 'should not convert colons in strings',
+    input: 'someFunction(name: "key:value")',
+    expected: 'someFunction(name = "key:value")',
+  },
+  {
+    name: 'should handle single-quoted strings',
+    input: "anotherFunction(label: 'example')",
+    expected: "anotherFunction(label = 'example')",
+  },
+];
+
+let failed = 0;
+
+testCases.forEach(({ name, input, expected }) => {
+  const actual = replaceColonWithEquals(input);
+  if (actual !== expected) {
+    console.error(`✗ ${name}`);
+    console.error(`  Input:    ${input}`);
+    console.error(`  Expected: ${expected}`);
+    console.error(`  Actual:   ${actual}`);
+    failed++;
+  } else {
+    console.log(`✓ ${name}`);
+  }
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed.`);
+  throw new Error('Tests failed');
+} else {
+  console.log('\nAll tests passed!');
+}

--- a/web/app/logic.ts
+++ b/web/app/logic.ts
@@ -434,7 +434,7 @@ export class GradleToKtsConverter {
   }
 
   private replaceColonWithEquals(text: string): string {
-    const expression = /\w*:\s*".*?"/g
+    const expression = /\b(\w+):\s*([^,)]+)/g
     return this.replaceWithCallback(text, expression, (match) => {
       return match[0].replace(":", " =")
     })


### PR DESCRIPTION
The `replaceColonWithEquals` function was using a regular expression that only handled named arguments with double-quoted string values. This caused the conversion from Gradle to Kotlin DSL to fail for other common data types like numbers, booleans, and single-quoted strings.

This commit updates the regular expression to be more robust, correctly identifying the key and value of a named argument regardless of the value's type.

Additionally, a permanent test file (`logic.test.ts`) has been added to verify this fix and prevent future regressions. The test file includes cases for strings, numbers, booleans, and single-quoted strings.