### PR TITLE
fix: harden converter edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ kotlinc -script kotlin/gradlekotlinconverter.kts build.gradle
 ./kotlin/gradlekotlinconverter.kts build.gradle
 ```
 
-The Kotlin script has full feature and test parity with the TypeScript version.
+The Kotlin script covers the core conversions; `web/` is the complete implementation with the full test suite and additional features.
 
 ### Developing the project
 

--- a/kotlin/gradlekotlinconverter.kts
+++ b/kotlin/gradlekotlinconverter.kts
@@ -140,7 +140,11 @@ fun String.convertVariableDeclaration(): String {
 // [appIcon: "@drawable/ic_launcher", appRoundIcon: "@null"]
 // becomes
 // mapOf(appIcon to "@drawable/ic_launcher", appRoundIcon to "@null"])
+// Also: [:] → mapOf() (only outside strings/comments)
 fun String.convertMapExpression(): String {
+    // Empty Groovy map [:] → mapOf()
+    val withEmptyMaps = this.replaceOutsideCode("""\[\s*:\s*\]""".toRegex()) { "mapOf()" }
+
     val key = """\w+"""
     val value = """[^,:\s\]]+"""
     val keyValueGroup = """\s*$key:\s*$value\s*"""
@@ -157,7 +161,7 @@ fun String.convertMapExpression(): String {
         }
     }
 
-    return this.replace(mapRegExp) { lineMatch ->
+    return withEmptyMaps.replace(mapRegExp) { lineMatch ->
         val matchesInKotlinCode = mutableListOf<String>()
         extractAllMatches(matchesInKotlinCode, lineMatch.groupValues[1])
         "mapOf(${matchesInKotlinCode.joinToString(", ")})"
@@ -175,18 +179,59 @@ fun String.convertManifestPlaceHoldersWithMap(): String {
     }
 }
 
+/** True when bracket contents look like a single index (ident/number/path), not a list. */
+fun looksLikeIndexExpression(trimmed: String): Boolean {
+    if (trimmed.isEmpty()) return false
+    if (trimmed.toIntOrNull() != null) return true
+    // identifier or a.b.c — not quoted strings, not comma-separated lists
+    return Regex("""^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$""").matches(trimmed)
+}
+
 // [1, 2]
 // becomes
-// listOf(1,2)
-// but keep probablyMyArrayLookup[42]
+// listOf(1, 2)
+// but keep array/map indexing: versionCodes[abiName], versionCodes [abiName], arr[42]
+// Spaced method args (dependsOn ["a", "b"]) still become listOf unless content is index-like.
 fun String.convertArrayExpression(): String {
     val arrayExp = """\[([^\]]*?)\]""".toRegex(DOT_MATCHES_ALL)
 
-    return this.replace(arrayExp) {
-        if (it.groupValues[1].toIntOrNull() != null) {
-            it.value // Its probably an array indexing, so keep original
+    return this.replace(arrayExp) { match ->
+        val content = match.groupValues[1]
+        val trimmed = content.trim()
+        val offset = match.range.first
+        if (this.isInsideStringOrComment(offset)) {
+            return@replace match.value
+        }
+        // Leftover empty-map syntax (normally converted earlier); keep as-is.
+        if (trimmed == ":") {
+            return@replace match.value
+        }
+
+        // Receiver immediately before `[` → always indexing
+        if (offset > 0 && this[offset - 1].let { it.isLetterOrDigit() || it == '_' || it == ')' || it == ']' }) {
+            return@replace match.value
+        }
+
+        // Spaced receiver: walk left over whitespace
+        var i = offset - 1
+        val hadSpace = i >= 0 && this[i].isWhitespace()
+        while (i >= 0 && this[i].isWhitespace()) i--
+        if (i >= 0 && hadSpace) {
+            val ch = this[i]
+            if (ch == ')' || ch == ']') {
+                return@replace match.value
+            }
+            if ((ch.isLetterOrDigit() || ch == '_') && looksLikeIndexExpression(trimmed)) {
+                // versionCodes [abiName]
+                return@replace match.value
+            }
+            // else: dependsOn ["clean", "build"], to ["*.jar"] → listOf
+        }
+
+        if (trimmed.isEmpty() || trimmed.toIntOrNull() != null) {
+            match.value
         } else {
-            "listOf(${it.groupValues[1]})"
+            "listOf($trimmed)"
         }
     }
 }
@@ -377,9 +422,14 @@ fun String.convertSigningConfigBuildType(): String {
     val outerExp = "signingConfig.*signingConfigs.*".toRegex()
 
     return this.replace(outerExp) {
-        // extracts release from signingConfig signingConfigs.release
-        val release = it.value.replace("signingConfig.*signingConfigs.".toRegex(), "")
-        "signingConfig = signingConfigs.getByName(\"$release\")"
+        // Already converted (idempotent on Kotlin DSL input)
+        if ("""\b(getByName|named)\s*\(""".toRegex().containsMatchIn(it.value)) {
+            it.value
+        } else {
+            // extracts release from signingConfig signingConfigs.release
+            val release = it.value.replace("signingConfig.*signingConfigs.".toRegex(), "")
+            "signingConfig = signingConfigs.getByName(\"$release\")"
+        }
     }
 }
 
@@ -434,10 +484,20 @@ fun String.convertSigningConfigs(): String = this.convertNestedTypes("signingCon
 
 
 fun String.convertNestedTypes(buildTypes: String, named: String): String {
+    // Only rewrite bare identifiers before `{` (e.g. `release {`).
+    // Skip already-converted forms like named("release") { / getByName("main") { / register("debug") {
     return this.getExpressionBlock("$buildTypes\\s*\\{".toRegex()) { substring ->
-        substring.replace("\\S*\\s(?=\\{)".toRegex()) {
-            val valueWithoutWhitespace = it.value.replace(" ", "")
-            "$named(\"$valueWithoutWhitespace\") "
+        substring.replace(Regex("(^|\\n)(\\s*)(\\w+)(\\s+)(?=\\{)", RegexOption.MULTILINE)) { m ->
+            val lineStart = m.groupValues[1]
+            val indent = m.groupValues[2]
+            val word = m.groupValues[3]
+            val space = m.groupValues[4]
+            // Skip outer keyword if present; also skip already-converted DSL helpers
+            if (word == buildTypes || word in setOf("named", "create", "register", "getByName")) {
+                m.value
+            } else {
+                "$lineStart$indent$named(\"$word\")$space"
+            }
         }
     }
 }
@@ -760,7 +820,7 @@ fun String.addParenthesisToId(): String {
 fun String.addEquals(): String {
     val compileSdk = "compileSdk"
     val signing = "keyAlias|keyPassword|storeFile|storePassword"
-    val other = "multiDexEnabled|correctErrorTypes|javaMaxHeapSize|jumboMode|dimension|useSupportLibrary|kotlinCompilerExtensionVersion|isCoreLibraryDesugaringEnabled"
+    val other = "multiDexEnabled|correctErrorTypes|javaMaxHeapSize|jumboMode|dimension|useSupportLibrary|kotlinCompilerExtensionVersion|isCoreLibraryDesugaringEnabled|buildToolsVersion"
     val databinding = "dataBinding|viewBinding"
     val defaultConfig = "applicationId|minSdk|targetSdk|versionCode|versionName|testInstrumentationRunner|namespace"
 
@@ -827,14 +887,61 @@ fun String.convertJavaCompatibility(): String {
 }
 
 
-// converts the clean task, which is very common to find
+// converts the clean task, which is very common to find.
+// Uses balanced braces so trailing content (e.g. allprojects { ... }) is preserved.
+// Note: getExpressionBlock only rewrites from `{` onward; clean needs the whole task header replaced.
 fun String.convertCleanTask(): String {
-
-    val cleanExp = "task clean\\(type: Delete\\)\\s*\\{[\\s\\S]*}".toRegex()
+    val cleanHeader = "task clean\\(type: Delete\\)\\s*\\{".toRegex()
     val registerClean = "tasks.register<Delete>(\"clean\").configure {\n" +
             "    delete(rootProject.buildDir)\n }"
 
-    return this.replace(cleanExp, registerClean)
+    val matches = cleanHeader.findAll(this).toList()
+    if (matches.isEmpty()) return this
+
+    return matches.foldRight(this) { matchResult, acc ->
+        val openBraceIndex = matchResult.range.last
+        var count = 0
+        var inString = false
+        var stringChar = ' '
+        var escaped = false
+        var endIndex = acc.length
+        var i = openBraceIndex
+        while (i < acc.length) {
+            val ch = acc[i]
+            if (escaped) {
+                escaped = false
+                i++
+                continue
+            }
+            if (ch == '\\') {
+                escaped = true
+                i++
+                continue
+            }
+            if (inString) {
+                if (ch == stringChar) inString = false
+                i++
+                continue
+            }
+            if (ch == '"' || ch == '\'') {
+                inString = true
+                stringChar = ch
+                i++
+                continue
+            }
+            if (ch == '{') {
+                count += 1
+            } else if (ch == '}') {
+                count -= 1
+                if (count == 0) {
+                    endIndex = i + 1
+                    break
+                }
+            }
+            i++
+        }
+        acc.replaceRange(matchResult.range.first, endIndex, registerClean)
+    }
 }
 
 
@@ -1023,14 +1130,107 @@ fun String.convertPluginsIntoOneBlock(): String {
     }
 }
 
+/**
+ * True when a colon at/after [offset] is a Groovy ternary false-branch colon
+ * (`? ... : ...`). Scans a limited window before [offset], ignoring `?` / `:`
+ * inside string literals and comments (including multiline ternaries).
+ */
+fun String.hasUnpairedTernaryQuestion(offset: Int): Boolean {
+    val windowStart = (offset - 500).coerceAtLeast(0)
+    var i = windowStart
+    var inString = false
+    var stringChar = ' '
+    var stringLen = 1
+    var inBlockComment = false
+    var inLineComment = false
+    var unpairedQuestion = false
+
+    while (i < offset) {
+        if (inLineComment) {
+            if (this[i] == '\n') inLineComment = false
+            i++
+            continue
+        }
+        if (inBlockComment) {
+            if (this[i] == '*' && i + 1 < length && this[i + 1] == '/') {
+                inBlockComment = false
+                i += 2
+                continue
+            }
+            i++
+            continue
+        }
+        if (inString) {
+            if (i + stringLen - 1 < length && this.substring(i, i + stringLen) == stringChar.toString().repeat(stringLen)) {
+                inString = false
+                i += stringLen
+                continue
+            }
+            if (stringLen == 1 && this[i] == '\\') {
+                i += 2
+                continue
+            }
+            i++
+            continue
+        }
+
+        if (this[i] == '/' && i + 1 < length && this[i + 1] == '*') {
+            inBlockComment = true
+            i += 2
+            continue
+        }
+        if (this[i] == '/' && i + 1 < length && this[i + 1] == '/') {
+            inLineComment = true
+            i += 2
+            continue
+        }
+        if (i + 2 < length) {
+            val tri = this.substring(i, i + 3)
+            if (tri == "\"\"\"" || tri == "'''") {
+                stringChar = tri[0]
+                stringLen = 3
+                inString = true
+                i += 3
+                continue
+            }
+        }
+        val ch = this[i]
+        if (ch == '"' || ch == '\'') {
+            stringChar = ch
+            stringLen = 1
+            inString = true
+            i++
+            continue
+        }
+        if (ch == '?') {
+            // Groovy safe-navigation `?.` is not a ternary question mark.
+            // Elvis `?:` is handled naturally: `?` then `:` clears the flag.
+            if (i + 1 >= length || this[i + 1] != '.') {
+                unpairedQuestion = true
+            }
+        } else if (ch == ':') {
+            unpairedQuestion = false
+        }
+        i++
+    }
+    return unpairedQuestion
+}
+
 // testImplementation(group: "junit", name: "junit", version: "4.12")
 // becomes
 // testImplementation(group = "junit", name = "junit", version = "4.12")
+// Does NOT rewrite ternary false-branch colons: isCi ? ciName : "local"
 fun String.replaceColonWithEquals(): String {
     // Convert parameter colons to = but ONLY when followed by a quote (named params),
-    // never colons inside dependency coordinate strings like "group:artifact:ver"
-    return this.replace("\\b(\\w+)\\s*:\\s*(?=[\"'])".toRegex()) {
-        it.value.replace(":", " =")
+    // never colons inside dependency coordinate strings like "group:artifact:ver",
+    // and never ternary `? ... : ...` colons (quote-aware, multiline window).
+    return this.replace("\\b(\\w+)\\s*:\\s*(?=[\"'])".toRegex()) { match ->
+        val offset = match.range.first
+        if (this.hasUnpairedTernaryQuestion(offset)) {
+            match.value // ternary colon
+        } else {
+            match.value.replace(":", " =")
+        }
     }
 }
 

--- a/kotlin/test.sh
+++ b/kotlin/test.sh
@@ -133,6 +133,79 @@ compare_inline \
   $'archivesBaseName = "random-app-$versionName"\n'
 
 echo
+echo "--- Bug regressions (mirror web/app/bug-regressions.spec.ts core cases) ---"
+
+compare_inline \
+  "bug1: clean task does not swallow trailing allprojects" \
+  $'task clean(type: Delete) {\n    delete rootProject.buildDir\n}\nallprojects {\n    repositories {\n        mavenCentral()\n    }\n}\n' \
+  $'tasks.register<Delete>("clean").configure {\n    delete(rootProject.buildDir)\n }\nallprojects {\n    repositories {\n        mavenCentral()\n    }\n}\n'
+
+compare_inline \
+  "bug2: empty Groovy map [:] becomes mapOf()" \
+  $'manifestPlaceholders = [:]\n' \
+  $'manifestPlaceholders.putAll(mapOf())\n'
+
+compare_inline \
+  "bug2e: [:] inside strings/comments is left alone" \
+  $'println "[:] empty"\n// use [:]\nmanifestPlaceholders = [:]\n' \
+  $'println "[:] empty"\n// use [:]\nmanifestPlaceholders.putAll(mapOf())\n'
+
+compare_inline \
+  "bug3: array indexing with variable is preserved" \
+  $'def code = versionCodes[abiName]\n' \
+  $'val code = versionCodes[abiName]\n'
+
+compare_inline \
+  "bug3d: spaced array indexing is preserved" \
+  $'def code = versionCodes [abiName]\n' \
+  $'val code = versionCodes [abiName]\n'
+
+compare_inline \
+  "bug3f: spaced method-call list args become listOf" \
+  $'dependsOn ["clean", "build"]\n' \
+  $'dependsOn listOf("clean", "build")\n'
+
+compare_inline \
+  "bug4: ternary false-branch colon is preserved" \
+  $'def name = isCi ? ciName : "local"\n' \
+  $'val name = isCi ? ciName : "local"\n'
+
+compare_inline \
+  "bug4c: ? inside strings does not block named params" \
+  $'exclude(group: "foo?", module: "bar")\n' \
+  $'exclude(group = "foo?", module = "bar")\n'
+
+compare_inline \
+  "bug4f: safe-navigation ?. does not block named params" \
+  $'foo(obj?.bar, group: "junit")\n' \
+  $'foo(obj?.bar, group = "junit")\n'
+
+compare_inline \
+  "bug4d: multiline ternary false-branch colon is preserved" \
+  $'def name = isCi ?\n    ciName : "local"\n' \
+  $'val name = isCi ?\n    ciName : "local"\n'
+
+compare_inline \
+  "bug5: already-converted getByName is not double-wrapped" \
+  $'signingConfig = signingConfigs.getByName("release")\n' \
+  $'signingConfig = signingConfigs.getByName("release")\n'
+
+compare_inline \
+  "bug5b: groovy signingConfig still converts" \
+  $'signingConfig signingConfigs.release\n' \
+  $'signingConfig = signingConfigs.getByName("release")\n'
+
+compare_inline \
+  "bug7: buildToolsVersion gets equals" \
+  $'buildToolsVersion "34.0.0"\n' \
+  $'buildToolsVersion = "34.0.0"\n'
+
+compare_inline \
+  "bug8: property after // comment line is still converted" \
+  $'// the namespace\nnamespace "com.example"\n' \
+  $'// the namespace\nnamespace = "com.example"\n'
+
+echo
 echo "=== Summary: ${passes} passed, ${failures} failed ==="
 
 if ((failures > 0)); then

--- a/web/app/bug-regressions.spec.ts
+++ b/web/app/bug-regressions.spec.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import { GradleToKtsConverter } from "./logic";
+
+/**
+ * Regression tests for confirmed converter bugs (clean-task swallow, empty maps,
+ * array indexing, ternaries, idempotency, buildToolsVersion, comment-line skip,
+ * outputs.all alias, mid-file ext blocks) and their edge-case follow-ups.
+ */
+describe("Bug regressions", () => {
+  const converter = new GradleToKtsConverter();
+
+  it("1: task clean does not swallow trailing content (allprojects)", () => {
+    const input = `task clean(type: Delete) {
+    delete rootProject.buildDir
+}
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain('tasks.register<Delete>("clean")');
+    expect(result).toContain("allprojects {");
+    expect(result).toContain("mavenCentral()");
+    expect(result).not.toContain("task clean");
+  });
+
+  it("1b: nested braces inside clean still preserve trailing content", () => {
+    const input = `task clean(type: Delete) {
+    doLast {
+        delete rootProject.buildDir
+    }
+}
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain('tasks.register<Delete>("clean")');
+    expect(result).toContain("allprojects {");
+    expect(result).toContain("mavenCentral()");
+    expect(result).not.toContain("task clean");
+  });
+
+  it("2: empty Groovy map [:] becomes mapOf()", () => {
+    const input = "manifestPlaceholders = [:]";
+    const result = converter.convert(input);
+    expect(result).toContain("mapOf()");
+    expect(result).not.toContain("listOf(:)");
+    expect(result).not.toContain("[:]");
+  });
+
+  it("2b: spaced empty map [ : ] becomes mapOf()", () => {
+    const result = converter.convert("manifestPlaceholders = [ : ]");
+    expect(result).toContain("mapOf()");
+    expect(result).not.toContain("listOf");
+  });
+
+  it("2c: non-empty map still converts to mapOf entries", () => {
+    const result = converter.convert('manifestPlaceholders = [appIcon: "@drawable/ic"]');
+    expect(result).toContain('mapOf("appIcon" to "@drawable/ic")');
+  });
+
+  it("2d: empty list [] is not treated as empty map", () => {
+    const result = converter.convert("def xs = []");
+    expect(result).not.toContain("mapOf()");
+    // empty [] without receiver stays as [] historically
+    expect(result).toContain("[]");
+  });
+
+  it("2e: [:] inside strings and comments is left alone", () => {
+    const input = `println "[:] empty"
+// use [:]
+manifestPlaceholders = [:]`;
+    const result = converter.convert(input);
+    expect(result).toContain('println "[:] empty"');
+    expect(result).toContain("// use [:]");
+    expect(result).toContain("mapOf()");
+  });
+
+  it("3: array indexing with a variable is preserved", () => {
+    const input = "def code = versionCodes[abiName]";
+    const result = converter.convert(input);
+    expect(result).toContain("versionCodes[abiName]");
+    expect(result).not.toContain("listOf(abiName)");
+    expect(result).not.toContain("versionCodeslistOf");
+  });
+
+  it("3b: array indexing with a numeric index is preserved", () => {
+    const input = "def code = versionCodes[0]";
+    const result = converter.convert(input);
+    expect(result).toContain("versionCodes[0]");
+  });
+
+  it("3c: list literals still convert to listOf", () => {
+    const input = "def xs = [1, 2, 3]";
+    const result = converter.convert(input);
+    expect(result).toContain("listOf(1, 2, 3)");
+  });
+
+  it("3d: spaced array indexing is preserved", () => {
+    const result = converter.convert("def code = versionCodes [abiName]");
+    expect(result).toContain("versionCodes [abiName]");
+    expect(result).not.toContain("listOf(abiName)");
+  });
+
+  it("3e: )[ and ][ receivers are preserved", () => {
+    const result = converter.convert(`def a = getVersions()[0]
+def b = matrix[i][j]`);
+    expect(result).toContain("getVersions()[0]");
+    expect(result).toContain("matrix[i][j]");
+    expect(result).not.toContain("listOf");
+  });
+
+  it("3f: spaced method-call list args still convert to listOf", () => {
+    const result = converter.convert('dependsOn ["clean", "build"]');
+    expect(result).toContain('listOf("clean", "build")');
+    expect(result).not.toMatch(/dependsOn\s+\[/);
+  });
+
+  it("3g: spaced single-string method arg still converts to listOf", () => {
+    const result = converter.convert('srcDirs ["src/main/kotlin"]');
+    expect(result).toContain('listOf("src/main/kotlin")');
+  });
+
+  it("4: ternary false-branch colon is not rewritten to =", () => {
+    const input = 'def name = isCi ? ciName : "local"';
+    const result = converter.convert(input);
+    expect(result).toContain('isCi ? ciName : "local"');
+    expect(result).not.toContain("ciName = ");
+  });
+
+  it("4b: named parameter colons still convert to =", () => {
+    const input = 'testImplementation(group: "junit", name: "junit", version: "4.12")';
+    const result = converter.convert(input);
+    expect(result).toContain('group = "junit"');
+    expect(result).toContain('name = "junit"');
+    expect(result).toContain('version = "4.12"');
+  });
+
+  it("4c: ? inside strings does not block later named params", () => {
+    const input = 'exclude(group: "foo?", module: "bar")';
+    const result = converter.convert(input);
+    expect(result).toContain('group = "foo?"');
+    expect(result).toContain('module = "bar"');
+    expect(result).not.toContain("module:");
+  });
+
+  it("4d: multiline ternary false-branch colon is preserved", () => {
+    const input = `def name = isCi ?
+    ciName : "local"`;
+    const result = converter.convert(input);
+    expect(result).toContain('ciName : "local"');
+    expect(result).not.toContain("ciName = ");
+  });
+
+  it("4e: mixed ternary and named params on one line", () => {
+    const input = 'foo(isCi ? ciName : "local", group: "junit")';
+    const result = converter.convert(input);
+    expect(result).toContain('isCi ? ciName : "local"');
+    expect(result).toContain('group = "junit"');
+    expect(result).not.toContain("ciName = ");
+  });
+
+  it("4f: safe-navigation ?. does not block later named params", () => {
+    const input = 'foo(obj?.bar, group: "junit")';
+    const result = converter.convert(input);
+    expect(result).toContain("obj?.bar");
+    expect(result).toContain('group = "junit"');
+    expect(result).not.toContain("group:");
+  });
+
+  it("4g: elvis ?: does not break ternary or named params", () => {
+    const ternary = converter.convert('def name = isCi ? ciName : "local"');
+    expect(ternary).toContain('isCi ? ciName : "local"');
+
+    const named = converter.convert('foo(value ?: "default", group: "junit")');
+    expect(named).toContain('group = "junit"');
+    expect(named).toContain('value ?: "default"');
+  });
+
+  it("5: already-converted getByName is not double-wrapped", () => {
+    const input = 'signingConfig = signingConfigs.getByName("release")';
+    const result = converter.convert(input);
+    expect(result).toContain('signingConfigs.getByName("release")');
+    expect(result).not.toContain('getByName("getByName');
+  });
+
+  it("5b: groovy signingConfig signingConfigs.release still converts", () => {
+    const input = "signingConfig signingConfigs.release";
+    const result = converter.convert(input);
+    expect(result).toBe('signingConfig = signingConfigs.getByName("release")');
+  });
+
+  it("5c: already-converted named() buildTypes is not double-wrapped", () => {
+    const input = `buildTypes {
+    named("release") {
+        minifyEnabled true
+    }
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain('named("release")');
+    expect(result).not.toContain('named("named")');
+    expect(result).toContain("isMinifyEnabled = true");
+  });
+
+  it("5d: convert-twice is idempotent for signing and buildTypes", () => {
+    const signingGroovy = "signingConfig signingConfigs.release";
+    const once = converter.convert(signingGroovy);
+    const twice = converter.convert(once);
+    expect(twice).toBe(once);
+
+    const buildTypesGroovy = `buildTypes {
+    release {
+        minifyEnabled true
+    }
+}`;
+    const btOnce = converter.convert(buildTypesGroovy);
+    const btTwice = converter.convert(btOnce);
+    expect(btTwice).toBe(btOnce);
+    expect(btOnce).toContain('named("release")');
+  });
+
+  it('7: buildToolsVersion "34.0.0" gets an equals', () => {
+    const input = 'buildToolsVersion "34.0.0"';
+    const result = converter.convert(input);
+    expect(result).toBe('buildToolsVersion = "34.0.0"');
+  });
+
+  it("8: property after // comment line is still converted", () => {
+    const input = `// the namespace
+namespace "com.example"`;
+    const result = converter.convert(input);
+    expect(result).toContain('namespace = "com.example"');
+  });
+
+  it("9: outputs.all with extra spaces keeps outputs prefix", () => {
+    const input = `variant.outputs.all  { output ->
+    output.versionCodeOverride = 1
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain("outputs.all { val output = this");
+    expect(result).not.toContain("applicationVariants.all");
+    expect(result).not.toContain("->");
+  });
+
+  it("9b: applicationVariants.all still aliases correctly", () => {
+    const input = `applicationVariants.all { variant ->
+    println(variant.name)
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain("applicationVariants.all { val variant = this");
+  });
+
+  it("10: mid-file ext { } does not emit stray TODO for the header", () => {
+    const input = `android {
+}
+
+ext {
+    foo = 1
+}`;
+    const result = converter.convert(input);
+    expect(result).toContain('extra["foo"] = 1');
+    expect(result).not.toContain("TODO: manually convert ext block line: ext {");
+  });
+});

--- a/web/app/logic.spec.ts
+++ b/web/app/logic.spec.ts
@@ -266,6 +266,7 @@ dependencies {
       expect(result).toContain('applicationId = "com.example.app"');
       expect(result).toContain("versionCode = 42");
       expect(result).toContain('versionName = "1.5.2"');
+      expect(result).toContain('buildToolsVersion = "34.0.0"');
     });
 
     it("should handle exclusions with colons correctly", () => {

--- a/web/app/logic.ts
+++ b/web/app/logic.ts
@@ -165,6 +165,11 @@ export class GradleToKtsConverter {
       i++;
     }
 
+    // If querying exactly at a \n that terminates a line comment, the following
+    // content (match starting here via (^|\n) anchors) is outside the comment.
+    if (pos < text.length && text[pos] === "\n" && inLineComment) {
+      inLineComment = false;
+    }
     return inString || inBlockComment || inLineComment;
   }
 
@@ -220,8 +225,10 @@ export class GradleToKtsConverter {
   }
 
   private convertMapExpression(text: string): string {
+    // Empty Groovy map [:] → mapOf() (only outside strings/comments)
+    let result = this.replaceOutsideCode(text, /\[\s*:\s*\]/g, () => "mapOf()");
     const mapRegExp = /\[(\s*\w+:\s*[^,:\s\]]+\s*(?:,\s*\w+:\s*[^,:\s\]]+\s*)*)\]/g;
-    return this.replaceWithCallback(text, mapRegExp, (match) => {
+    return this.replaceWithCallback(result, mapRegExp, (match) => {
       const entries = match[1].split(",").map((entry) => {
         const [key, value] = entry.split(":").map((s) => s.trim());
         return `"${key}" to ${value}`;
@@ -240,10 +247,60 @@ export class GradleToKtsConverter {
     });
   }
 
+  /**
+   * True when bracket contents look like a single index expression (identifier,
+   * number, or simple dotted path) rather than a list literal.
+   */
+  private looksLikeIndexExpression(trimmed: string): boolean {
+    if (!trimmed) return false;
+    if (/^\d+$/.test(trimmed)) return true;
+    // identifier or a.b.c — not quoted strings, not comma-separated lists
+    if (/^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$/.test(trimmed)) return true;
+    return false;
+  }
+
   private convertArrayExpression(text: string): string {
-    return this.replaceWithCallback(text, /\[([^\]]*?)\]/g, (match) => {
-      const content = match[1].trim();
-      return content && !/^\d+$/.test(content) ? `listOf(${content})` : match[0];
+    // Convert list literals [a, b] → listOf(a, b), but preserve array/map indexing
+    // like versionCodes[abiName], versionCodes [abiName], arr[0], get()[i], matrix[i][j].
+    // Spaced forms after identifiers (dependsOn ["a", "b"]) are list args unless the
+    // bracket content looks like a single index expression.
+    return text.replace(/\[([^\]]*?)\]/g, (full, content, offset: number) => {
+      if (this.isInsideStringOrComment(text, offset)) {
+        return full;
+      }
+      const trimmed = content.trim();
+      // Leftover empty-map syntax (normally converted earlier); keep as-is.
+      if (trimmed === ":") {
+        return full;
+      }
+
+      // Receiver immediately before `[` → always indexing
+      if (offset > 0 && /[\w)\]]/.test(text[offset - 1])) {
+        return full;
+      }
+
+      // Spaced receiver: walk left over whitespace
+      let i = offset - 1;
+      const hadSpace = i >= 0 && /\s/.test(text[i]);
+      while (i >= 0 && /\s/.test(text[i])) i--;
+      if (i >= 0 && hadSpace) {
+        if (text[i] === ")" || text[i] === "]") {
+          // getVersions() [0] / matrix[i] [j]
+          return full;
+        }
+        if (/[\w]/.test(text[i]) && this.looksLikeIndexExpression(trimmed)) {
+          // versionCodes [abiName] — single index-like content after identifier
+          return full;
+        }
+        // else: dependsOn ["clean", "build"], files ["x"], to ["*.jar"] → listOf
+      }
+
+      // Numeric-only inside [] without a receiver is still a one-element list, but
+      // keep the historical guard for bare [0]-style lookups that lack a clear receiver.
+      if (!trimmed || /^\d+$/.test(trimmed)) {
+        return full;
+      }
+      return `listOf(${trimmed})`;
     });
   }
 
@@ -380,7 +437,8 @@ export class GradleToKtsConverter {
       return block.replace(
         /(^|\n)(\s*)(\w+)\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')/g,
         (m, lineStart, indent, configName, quoted) => {
-          const known = /^(implementation|api|testImplementation|androidTestImplementation|debugImplementation|releaseImplementation|compileOnly|testCompileOnly|runtimeOnly|testRuntimeOnly|androidTestRuntimeOnly|debugRuntimeOnly|releaseRuntimeOnly|developmentOnly|classpath|kapt|kaptTest|kaptAndroidTest|annotationProcessor|ksp|coreLibraryDesugaring|detektPlugins|lintPublish|lintCheck|modImplementation|modApi)$/;
+          const known =
+            /^(implementation|api|testImplementation|androidTestImplementation|debugImplementation|releaseImplementation|compileOnly|testCompileOnly|runtimeOnly|testRuntimeOnly|androidTestRuntimeOnly|debugRuntimeOnly|releaseRuntimeOnly|developmentOnly|classpath|kapt|kaptTest|kaptAndroidTest|annotationProcessor|ksp|coreLibraryDesugaring|detektPlugins|lintPublish|lintCheck|modImplementation|modApi)$/;
           if (known.test(configName) || configName === "dependencies") return m;
           return `${lineStart}${indent}"${configName}"(${quoted})`;
         },
@@ -486,6 +544,7 @@ export class GradleToKtsConverter {
       "isCoreLibraryDesugaringEnabled",
       "dataBinding",
       "viewBinding",
+      "buildToolsVersion",
     ];
     // Use word boundary to prevent matching substrings like "compileSdk" in "compileSdkVersion"
     const versionExp = new RegExp(
@@ -518,11 +577,12 @@ export class GradleToKtsConverter {
   }
 
   private convertCleanTask(text: string): string {
-    const cleanExp = /task clean\(type: Delete\)\s*\{[\s\S]*}/g;
+    // Match only the clean task block (balanced braces), not the rest of the file.
+    const cleanHeader = /task clean\(type: Delete\)\s*\{/g;
     const registerClean = `tasks.register<Delete>("clean").configure {
     delete(rootProject.buildDir)
  }`;
-    return text.replace(cleanExp, registerClean);
+    return this.getExpressionBlock(text, cleanHeader, () => registerClean);
   }
 
   private convertProguardFiles(text: string): string {
@@ -633,6 +693,10 @@ export class GradleToKtsConverter {
   private convertSigningConfigBuildType(text: string): string {
     const outerExp = /signingConfig.*signingConfigs.*/g;
     return this.replaceWithCallback(text, outerExp, (match) => {
+      // Already converted (idempotent on Kotlin DSL input)
+      if (/\b(getByName|named)\s*\(/.test(match[0])) {
+        return match[0];
+      }
       const release = match[0].replace(/signingConfig.*signingConfigs\./, "");
       return `signingConfig = signingConfigs.getByName("${release}")`;
     });
@@ -649,7 +713,12 @@ export class GradleToKtsConverter {
   private convertExtBlocksToExtra(text: string): string {
     const regex = /(^|\n)([\t ]*)ext\s*\{/g;
     return this.getExpressionBlock(text, regex, (block) => {
-      const lines = block.split("\n");
+      // When the match includes a leading \n (from (^|\n)), the block starts with a
+      // blank line and "ext {" lands in the body — strip that leading empty line.
+      let lines = block.split("\n");
+      if (lines.length > 0 && lines[0].trim() === "") {
+        lines = lines.slice(1);
+      }
       if (lines.length < 2) return block;
 
       const firstLine = lines[0];
@@ -696,10 +765,102 @@ export class GradleToKtsConverter {
     });
   }
 
+  /**
+   * True when the colon at/after `offset` is a Groovy ternary false-branch colon
+   * (`? ... : ...`). Scans a limited window before `offset`, ignoring `?` / `:`
+   * inside string literals and comments (including multiline ternaries).
+   */
+  private hasUnpairedTernaryQuestion(text: string, offset: number): boolean {
+    const windowStart = Math.max(0, offset - 500);
+    let i = windowStart;
+    let inString = false;
+    let stringDelim = "";
+    let stringLen = 1;
+    let inBlockComment = false;
+    let inLineComment = false;
+    let unpairedQuestion = false;
+
+    while (i < offset) {
+      if (inLineComment) {
+        if (text[i] === "\n") inLineComment = false;
+        i++;
+        continue;
+      }
+      if (inBlockComment) {
+        if (text[i] === "*" && text[i + 1] === "/") {
+          inBlockComment = false;
+          i += 2;
+          continue;
+        }
+        i++;
+        continue;
+      }
+      if (inString) {
+        if (text.startsWith(stringDelim, i)) {
+          inString = false;
+          i += stringLen;
+          continue;
+        }
+        if (stringLen === 1 && text[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        i++;
+        continue;
+      }
+
+      if (text[i] === "/" && text[i + 1] === "*") {
+        inBlockComment = true;
+        i += 2;
+        continue;
+      }
+      if (text[i] === "/" && text[i + 1] === "/") {
+        inLineComment = true;
+        i += 2;
+        continue;
+      }
+      if (i + 2 < text.length) {
+        const tri = text.slice(i, i + 3);
+        if (tri === '"""' || tri === "'''") {
+          stringDelim = tri;
+          stringLen = 3;
+          inString = true;
+          i += 3;
+          continue;
+        }
+      }
+      const ch = text[i];
+      if (ch === '"' || ch === "'") {
+        stringDelim = ch;
+        stringLen = 1;
+        inString = true;
+        i++;
+        continue;
+      }
+      if (ch === "?") {
+        // Groovy safe-navigation `?.` is not a ternary question mark.
+        // Elvis `?:` is handled naturally: `?` then `:` clears the flag.
+        if (text[i + 1] !== ".") {
+          unpairedQuestion = true;
+        }
+      } else if (ch === ":") {
+        unpairedQuestion = false;
+      }
+      i++;
+    }
+    return unpairedQuestion;
+  }
+
   private replaceColonWithEquals(text: string): string {
-    // This function converts parameter colons to equals signs (e.g., name: "value" -> name = "value"),
-    // but must avoid converting colons inside quoted strings (like dependency coordinates "org:artifact:version")
-    return text.replace(/\b(\w+)\s*:\s*(?=["'])/g, "$1 = ");
+    // Convert parameter colons to equals (name: "value" -> name = "value"),
+    // but never colons inside quoted strings, and never ternary false-branch colons
+    // (isCi ? ciName : "local"), including multiline and `?` inside strings.
+    return text.replace(/\b(\w+)\s*:\s*(?=["'])/g, (match, key, offset: number) => {
+      if (this.hasUnpairedTernaryQuestion(text, offset)) {
+        return match; // ternary colon
+      }
+      return `${key} = `;
+    });
   }
 
   private convertBuildTypes(text: string): string {
@@ -711,11 +872,7 @@ export class GradleToKtsConverter {
   }
 
   private convertFlavorDimensionProperty(text: string): string {
-    return this.replaceOutsideCode(
-      text,
-      /\bdimension\s+("[^"]+")/g,
-      (m) => `dimension = ${m[1]}`,
-    );
+    return this.replaceOutsideCode(text, /\bdimension\s+("[^"]+")/g, (m) => `dimension = ${m[1]}`);
   }
 
   private convertSourceSets(text: string): string {
@@ -776,15 +933,23 @@ ${indent}}`;
     // We are conservative: skip names that are commonly used inside plugin DSLs
     // that happen to use a nested "configurations { ... }" structure (e.g. jOOQ plugin).
     const nonConfigNames = new Set([
-      "main", "test", "integrationTest",
-      "generationTool", "jdbc", "generator", "database", "target", "logging",
+      "main",
+      "test",
+      "integrationTest",
+      "generationTool",
+      "jdbc",
+      "generator",
+      "database",
+      "target",
+      "logging",
     ]);
     const regex = /configurations\s*\{/g;
     return this.getExpressionBlock(text, regex, (substring) => {
       return substring.replace(
         /(^|\n)(\s*)(\w+)(\s*(?:\{|$))/gm,
         (m, lineStart, indent, name, rest) => {
-          if (["configurations", "create", "register", "named", "getByName"].includes(name)) return m;
+          if (["configurations", "create", "register", "named", "getByName"].includes(name))
+            return m;
           if (nonConfigNames.has(name)) return m;
           return `${lineStart}${indent}create("${name}")${rest}`;
         },
@@ -794,14 +959,14 @@ ${indent}}`;
 
   private convertNestedTypes(text: string, buildTypes: string, named: string): string {
     const regex = new RegExp(`${buildTypes}\\s*\\{`, "g");
+    const skipWords = new Set([buildTypes, "named", "create", "register", "getByName"]);
     return this.getExpressionBlock(text, regex, (substring) => {
       // Match optional leading whitespace, then word, then whitespace before {
-      // but skip if it's the buildTypes keyword
+      // Skip outer keyword and already-converted DSL helpers.
       return substring.replace(
         /(^|\n)(\s*)(\w+)(\s+)(?=\{)/gm,
         (match, lineStart, indent, word, space) => {
-          // Skip the outer keyword (buildTypes, productFlavors, etc.)
-          if (word === buildTypes) {
+          if (skipWords.has(word)) {
             return match;
           }
           return `${lineStart}${indent}${named}("${word}")${space}`;
@@ -966,25 +1131,16 @@ ${indent}}`;
 
   private convertAllLambdaParamToThisAlias(text: string): string {
     // Rewrite foo.all { name -> ... } to foo.all { val name = this ... }
-    // Applied to common Gradle DomainObjectSet collections: applicationVariants, outputs
-    const patterns = [
-      /applicationVariants\.all\s*\{\s*(\w+)\s*->/g,
-      /outputs\.all\s*\{\s*(\w+)\s*->/g,
-    ];
+    // Applied independently to common DomainObjectSet collections.
     let out = text;
-    for (const re of patterns) {
-      out = out.replace(re, (_m, name) => {
-        return `applicationVariants.all { val ${name} = this`; // placeholder; fix for outputs below
-      });
-      // fix outputs case where prefix got wrong
-      out = out.replace(
-        /applicationVariants\.all \{ val (\w+) = this(?=[^\n]*outputs\.all)/g,
-        (m) => m,
-      );
-      out = out.replace(/outputs\.all \{\s*(\w+)\s*->/g, (_m, name) => {
-        return `outputs.all { val ${name} = this`;
-      });
-    }
+    out = out.replace(
+      /applicationVariants\.all\s*\{\s*(\w+)\s*->/g,
+      (_m, name) => `applicationVariants.all { val ${name} = this`,
+    );
+    out = out.replace(
+      /outputs\.all\s*\{\s*(\w+)\s*->/g,
+      (_m, name) => `outputs.all { val ${name} = this`,
+    );
     return out;
   }
 


### PR DESCRIPTION
## What changed

- fixes converter handling for clean task blocks, empty maps, array indexing, ternary expressions, signing/build type idempotency, `buildToolsVersion`, comment boundaries, variant output aliases, and mid-file `ext` blocks
- mirrors the core fixes in the Kotlin script
- adds focused TypeScript and Kotlin regression coverage
- clarifies that the web implementation has the complete feature set

## Why

Several Groovy constructs could be over-converted, double-converted, or consume unrelated trailing content. These changes make the transformations safer while preserving existing behavior.

## Impact

Users get more reliable Groovy-to-Kotlin DSL output for these edge cases, with parity checks for the Kotlin script.

## Validation

- 132 Vitest tests passed (1 existing todo)
- TypeScript type-check passed
- oxlint passed
- changed TypeScript files pass oxfmt
- Next.js production build passed
- Kotlin suite: 30 passed, 0 failed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Groovy-to-Kotlin DSL conversion for maps, lists, array indexing, ternary expressions, comments, and strings.
  - Preserved surrounding build configuration when converting `clean` tasks.
  - Prevented duplicate transformations for already-converted signing configurations and DSL blocks.
  - Correctly converted `buildToolsVersion` declarations to assignment syntax.
  - Improved handling of dependency lists, nested configurations, and variant/output blocks.

- **Documentation**
  - Clarified that the Kotlin script supports core conversions, while the web implementation provides the complete feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->